### PR TITLE
fix: error on formatting empty list

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,17 @@
   "categories": [
     "Formatters"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onLanguage:scheme"
+  ],
   "main": "./out/extension.js",
   "contributes": {
     "languages": [
       {
         "id": "scheme",
+        "aliases": [
+          "Scheme"
+        ],
         "extensions": [
           ".scm"
         ]

--- a/scheme-fmt.py
+++ b/scheme-fmt.py
@@ -128,7 +128,7 @@ class ParserFormatter:
 
         while True:
             elem = self.parse_expr()
-            if not elem or elem == expr.END:
+            if (elem is None or elem == expr.END):
                 break
             expr.append(elem)
 

--- a/scheme-fmt.py
+++ b/scheme-fmt.py
@@ -128,7 +128,7 @@ class ParserFormatter:
 
         while True:
             elem = self.parse_expr()
-            if (elem is None or elem == expr.END):
+            if elem is None or elem == expr.END:
                 break
             expr.append(elem)
 


### PR DESCRIPTION
The formatter threw an error in any files with an empty list following another parentheses. This is because `not elem` is true when elem is an empty List, causing the loop to break and for it to never get appended to the expression. Then, the error got raised, because `elem` was not a closing parentheses. This is fixed by checking for `elem is None` instead.

Additionally, scheme was missing in the `activationEvents` property.

Fixes #1